### PR TITLE
feat: 준비 시간 추가 & 일정 생성 수정

### DIFF
--- a/src/main/java/org/imgoing/api/controller/PlanController.java
+++ b/src/main/java/org/imgoing/api/controller/PlanController.java
@@ -32,8 +32,8 @@ public class PlanController {
             @ApiResponse(code = 201, message = "일정 생성 성공", response = PlanDto.class),
             @ApiResponse(code = 400, message = "일정 생성 실패")
     })
-    public ImgoingResponse<PlanDto> create(User user, @RequestBody @Valid PlanDto planDto) {
-        Plan plan = planService.createPlan(user, planDto);
+    public ImgoingResponse<PlanDto> create(User user, @RequestBody @Valid PlanDto.Create planSaveRequest) {
+        Plan plan = planService.createPlan(user, planSaveRequest);
         return new ImgoingResponse<>(planMapper.toDto(plan, plan.getTaskList()), HttpStatus.CREATED);
     }
 
@@ -41,7 +41,7 @@ public class PlanController {
     @GetMapping
     @ApiResponse(code = 200, message = "일정 전체 조회 성공", response = List.class)
     public ImgoingResponse<List<PlanDto>> getAllPlans(User user) {
-        List<PlanDto> planDtos = planService.getPlans(user.getId()).stream()
+        List<PlanDto> planDtos = planService.getPlansByUser(user).stream()
                 .map(plan -> planMapper.toDto(plan, plan.getTaskList()))
                 .collect(Collectors.toList());
 

--- a/src/main/java/org/imgoing/api/domain/entity/Plan.java
+++ b/src/main/java/org/imgoing/api/domain/entity/Plan.java
@@ -67,10 +67,15 @@ public class Plan extends BaseTime {
         this.plantasks.clear();
         List<Plantask> plantasks = tasks.stream()
                 .map(task -> Plantask.builder()
-                .plan(this)
-                .task(task)
-                .build())
-                .collect(Collectors.toList());
+                        .plan(this)
+                        .task(task)
+                        .build()
+                ).collect(Collectors.toList());
+        this.plantasks.addAll(plantasks);
+    }
+
+    public void registerPlantasks(List<Plantask> plantasks) {
+        this.plantasks.clear();
         this.plantasks.addAll(plantasks);
     }
 

--- a/src/main/java/org/imgoing/api/dto/PlanDto.java
+++ b/src/main/java/org/imgoing/api/dto/PlanDto.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.validator.constraints.Length;
-import org.imgoing.api.domain.entity.Plan;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -65,4 +64,15 @@ public class PlanDto {
 
     @ApiModelProperty(value = "준비항목")
     private List<TaskDto> task;
+
+    @SuperBuilder
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @ApiModel(value = "플랜 생성 모델")
+    public static class Create extends PlanDto {
+        @ApiModelProperty(value = "북마크 리스트")
+        private List<Long> bookmarkedTaskIds;
+    }
 }

--- a/src/main/java/org/imgoing/api/dto/TaskDto.java
+++ b/src/main/java/org/imgoing/api/dto/TaskDto.java
@@ -20,7 +20,7 @@ public class TaskDto {
     @ApiModelProperty(value = "준비항목 시간")
     private Integer time;
 
-    @ApiModelProperty(value = "북마크 여부")
+    @ApiModelProperty(value = "북마크 여부", example = "false")
     private Boolean isBookmarked;
 
     @SuperBuilder

--- a/src/main/java/org/imgoing/api/mapper/PlanMapper.java
+++ b/src/main/java/org/imgoing/api/mapper/PlanMapper.java
@@ -1,9 +1,9 @@
 package org.imgoing.api.mapper;
 
 import org.imgoing.api.domain.entity.Task;
+import org.imgoing.api.domain.entity.User;
 import org.imgoing.api.dto.PlanDto;
 import org.imgoing.api.domain.entity.Plan;
-import org.imgoing.api.dto.TaskDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -17,4 +17,8 @@ public interface PlanMapper {
     PlanDto toDto(Plan plan, List<Task> tasks);
 
     Plan toEntity(PlanDto planDto);
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "user", source = "user")
+    Plan toEntityForSave(User user, PlanDto.Create dto);
 }

--- a/src/main/java/org/imgoing/api/repository/PlanRepository.java
+++ b/src/main/java/org/imgoing/api/repository/PlanRepository.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 
 public interface PlanRepository extends JpaRepository<Plan, Long> {
     @Query(value = "SELECT * FROM plan_tb WHERE plan_tb.user_id = :userId", nativeQuery = true)
-    List<Task> findAllByUserId(Long userId);
+    List<Plan> findAllByUserId(Long userId);
 
     Optional<Plan> findTopByUserAndArrivalAtGreaterThanOrderByArrivalAtAsc (User user, LocalDateTime now);
 }

--- a/src/main/java/org/imgoing/api/repository/TaskRepository.java
+++ b/src/main/java/org/imgoing/api/repository/TaskRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface TaskRepository extends JpaRepository<Task, Long> {
     @Query(value = "SELECT * FROM task_tb WHERE task_tb.user_id = :userId", nativeQuery = true)
     List<Task> findAllByUserId(Long userId);
+
+    List<Task> findAllByIdIn(List<Long> taskIds);
 }


### PR DESCRIPTION
## Summary
- startLat, Lng 이용하는 부분 추가
- Task Time 합쳐서 준비 시작까지 남은 시간 알 수 있게 마무리 함
- 테스트 하던 중 일정 생성 부분 코드가 읽기 힘들고 의존성이 너무 얽혀있어서 해당 부분 수정해봄

## 리뷰하기 전에,
### 관심사 1
Service에서 다른 Service를 호출하게 되면 **의존성이 서로 엮이게 되어서 강한 결합성을 가지게 될 가능성이 큼**.
즉, 어떤 서비스를 수정하려면 다른 서비스에 얽혀있지 않은지, 영향이 가지 않는지 확인해야 하는 상황이 찾아오게 됨.
이렇게 코드를 작성하게 되면 당연히 점점 수정하기 어려운 코드가 될 것이고 레거시 코드가 될 가능성이 큼.
또한 Controller - Service - Repository와 같이 우리가 계층을 나눈 이유도 없어지게 됨.

### 관심사 2
A 서비스에서도 반복되고, B 서비스에서도 반복되는 로직이 존재한다고 가정해보면,
**"어? 이거 반복되네 B 서비스에 이거 만들어서 써야겠다!"** 하고 A 서비스에서도 해당 함수를 쓰게 되었다고 가정.
그런데 A 서비스와 B 서비스에서 중복되는 부분이  사실 알고보니 다르게 발전하는 코드였음.
고치려고 하니 이미 너무 얽혀있어서 막막함.
이런 중복을 함수로 분리하는 문제는 같은 서비스 내에서도 일어날 수 있음.
중복이 정말 동일한 중복이 아닌지 고려해보고 함수로 분리하는 것을 고민해봐야 함.

### 우리 팀원들에게
당연히 내가 작성한 코드도 "완벽하다!"라고 말하기 어렵지만, 
최대한 의존성을 줄이고 변수 이름에 의미를 주어 읽기 쉬운 코드로 재편하고자 했다는 점을 고려해주면 좋을 듯!