### PR TITLE
Routine, Task 접근 시 권한 체크 기능 추가

### DIFF
--- a/src/main/java/org/imgoing/api/application/interceptor/RoutinePermissionInterceptor.java
+++ b/src/main/java/org/imgoing/api/application/interceptor/RoutinePermissionInterceptor.java
@@ -27,20 +27,18 @@ public class RoutinePermissionInterceptor implements HandlerInterceptor {
         String requestHttpMethod = request.getMethod();
         Map<?, ?> pathVariables = (Map<?, ?>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
 
-        if( (HttpMethod.GET.matches(requestHttpMethod) && !pathVariables.isEmpty())
+        if((HttpMethod.GET.matches(requestHttpMethod) && !pathVariables.isEmpty())
                 || HttpMethod.PUT.matches(requestHttpMethod)
-                || HttpMethod.DELETE.matches(requestHttpMethod) ) {
+                || HttpMethod.DELETE.matches(requestHttpMethod)) {
             TokenPayload payload = certificateAuthority.decrypt(request.getHeader("x-access-token"));
 
             Long id = Long.parseLong((String)pathVariables.get("routineId"));
 
-            Routine data = routineRepository.findById(id)
+            Routine routine = routineRepository.findById(id)
                     .orElseThrow(() -> new ImgoingException(ImgoingError.BAD_REQUEST, "존재하지 않는 루틴입니다."));
 
-            if(data.getUser().getId() == payload.getId()) {
-                return true;
-            }
-            throw new ImgoingException(ImgoingError.BAD_REQUEST, "접근할 수 없는 컨텐츠 입니다.");
+            if(routine.getUser().getId() == payload.getId()) return true;
+            else throw new ImgoingException(ImgoingError.BAD_REQUEST, "접근할 수 없는 컨텐츠 입니다.");
         } else return true;
     }
 }

--- a/src/main/java/org/imgoing/api/application/interceptor/RoutinePermissionInterceptor.java
+++ b/src/main/java/org/imgoing/api/application/interceptor/RoutinePermissionInterceptor.java
@@ -37,6 +37,8 @@ public class RoutinePermissionInterceptor implements HandlerInterceptor {
             Routine routine = routineRepository.findById(id)
                     .orElseThrow(() -> new ImgoingException(ImgoingError.BAD_REQUEST, "존재하지 않는 루틴입니다."));
 
+            request.setAttribute("routine", routine);
+
             if(routine.getUser().getId() == payload.getId()) return true;
             else throw new ImgoingException(ImgoingError.BAD_REQUEST, "접근할 수 없는 컨텐츠 입니다.");
         } else return true;

--- a/src/main/java/org/imgoing/api/application/interceptor/RoutinePermissionInterceptor.java
+++ b/src/main/java/org/imgoing/api/application/interceptor/RoutinePermissionInterceptor.java
@@ -1,0 +1,46 @@
+package org.imgoing.api.application.interceptor;
+
+import lombok.RequiredArgsConstructor;
+import org.imgoing.api.domain.entity.CertificateAuthority;
+import org.imgoing.api.domain.entity.Routine;
+import org.imgoing.api.domain.vo.TokenPayload;
+import org.imgoing.api.service.RoutineService;
+import org.imgoing.api.support.ImgoingError;
+import org.imgoing.api.support.ImgoingException;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class RoutinePermissionInterceptor implements HandlerInterceptor {
+    private final RoutineService routineService;
+    private final CertificateAuthority certificateAuthority;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String requestHttpMethod = request.getMethod();
+        Map<?, ?> pathVariables = (Map<?, ?>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+
+        if( (HttpMethod.GET.matches(requestHttpMethod) && !pathVariables.isEmpty())
+                || HttpMethod.PUT.matches(requestHttpMethod)
+                || HttpMethod.DELETE.matches(requestHttpMethod) ) {
+            TokenPayload payload = certificateAuthority.decrypt(request.getHeader("x-access-token"));
+            String[] path = routineService.getClass().getSuperclass().toString().split("\\.");
+            String entityName = path[path.length - 1].toLowerCase().replace("service", "");
+
+            Long id = Long.parseLong((String)pathVariables.get(entityName + "Id"));
+
+            Routine data = routineService.getById(id);
+            if(data.getUser().getId() == payload.getId()) {
+                return true;
+            }
+            throw new ImgoingException(ImgoingError.BAD_REQUEST, "접근할 수 없는 컨텐츠 입니다.");
+        } else return true;
+    }
+}

--- a/src/main/java/org/imgoing/api/application/interceptor/TaskPermissionInterceptor.java
+++ b/src/main/java/org/imgoing/api/application/interceptor/TaskPermissionInterceptor.java
@@ -1,0 +1,46 @@
+package org.imgoing.api.application.interceptor;
+
+import lombok.RequiredArgsConstructor;
+import org.imgoing.api.domain.entity.CertificateAuthority;
+import org.imgoing.api.domain.entity.Task;
+import org.imgoing.api.domain.vo.TokenPayload;
+import org.imgoing.api.service.TaskService;
+import org.imgoing.api.support.ImgoingError;
+import org.imgoing.api.support.ImgoingException;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.HandlerMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class TaskPermissionInterceptor implements HandlerInterceptor {
+    private final TaskService taskService;
+    private final CertificateAuthority certificateAuthority;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+        String requestHttpMethod = request.getMethod();
+        Map<?, ?> pathVariables = (Map<?, ?>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
+
+        if( (HttpMethod.GET.matches(requestHttpMethod) && !pathVariables.isEmpty())
+                || HttpMethod.PUT.matches(requestHttpMethod)
+                || HttpMethod.DELETE.matches(requestHttpMethod) ) {
+            TokenPayload payload = certificateAuthority.decrypt(request.getHeader("x-access-token"));
+            String[] path = taskService.getClass().getSuperclass().toString().split("\\.");
+            String entityName = path[path.length - 1].toLowerCase().replace("service", "");
+
+            Long id = Long.parseLong((String)pathVariables.get(entityName + "Id"));
+
+            Task data = taskService.getById(id);
+            if(data.getUser().getId() == payload.getId()) {
+                return true;
+            }
+            throw new ImgoingException(ImgoingError.BAD_REQUEST, "접근할 수 없는 컨텐츠 입니다.");
+        } else return true;
+    }
+}

--- a/src/main/java/org/imgoing/api/application/interceptor/TaskPermissionInterceptor.java
+++ b/src/main/java/org/imgoing/api/application/interceptor/TaskPermissionInterceptor.java
@@ -27,20 +27,18 @@ public class TaskPermissionInterceptor implements HandlerInterceptor {
         String requestHttpMethod = request.getMethod();
         Map<?, ?> pathVariables = (Map<?, ?>) request.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
 
-        if( (HttpMethod.GET.matches(requestHttpMethod) && !pathVariables.isEmpty())
+        if((HttpMethod.GET.matches(requestHttpMethod) && !pathVariables.isEmpty())
                 || HttpMethod.PUT.matches(requestHttpMethod)
-                || HttpMethod.DELETE.matches(requestHttpMethod) ) {
+                || HttpMethod.DELETE.matches(requestHttpMethod)) {
             TokenPayload payload = certificateAuthority.decrypt(request.getHeader("x-access-token"));
 
             Long id = Long.parseLong((String)pathVariables.get("taskId"));
 
-            Task data = taskRepository.findById(id)
+            Task task = taskRepository.findById(id)
                     .orElseThrow(() -> new ImgoingException(ImgoingError.BAD_REQUEST, "존재하지 않는 준비항목입니다."));
 
-            if(data.getUser().getId() == payload.getId()) {
-                return true;
-            }
-            throw new ImgoingException(ImgoingError.BAD_REQUEST, "접근할 수 없는 컨텐츠 입니다.");
+            if(task.getUser().getId() == payload.getId()) return true;
+            else throw new ImgoingException(ImgoingError.BAD_REQUEST, "접근할 수 없는 컨텐츠 입니다.");
         } else return true;
     }
 }

--- a/src/main/java/org/imgoing/api/application/interceptor/TaskPermissionInterceptor.java
+++ b/src/main/java/org/imgoing/api/application/interceptor/TaskPermissionInterceptor.java
@@ -37,6 +37,8 @@ public class TaskPermissionInterceptor implements HandlerInterceptor {
             Task task = taskRepository.findById(id)
                     .orElseThrow(() -> new ImgoingException(ImgoingError.BAD_REQUEST, "존재하지 않는 준비항목입니다."));
 
+            request.setAttribute("task", task);
+
             if(task.getUser().getId() == payload.getId()) return true;
             else throw new ImgoingException(ImgoingError.BAD_REQUEST, "접근할 수 없는 컨텐츠 입니다.");
         } else return true;

--- a/src/main/java/org/imgoing/api/config/WebMvcConfig.java
+++ b/src/main/java/org/imgoing/api/config/WebMvcConfig.java
@@ -1,18 +1,23 @@
 package org.imgoing.api.config;
 
 import lombok.RequiredArgsConstructor;
+import org.imgoing.api.application.interceptor.RoutinePermissionInterceptor;
+import org.imgoing.api.application.interceptor.TaskPermissionInterceptor;
 import org.imgoing.api.application.resolver.UserArgumentResolver;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
 
-@RequiredArgsConstructor
 @Configuration
+@RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
     private final UserArgumentResolver userArgumentResolver;
+    private final TaskPermissionInterceptor taskPermissionInterceptor;
+    private final RoutinePermissionInterceptor routinePermissionInterceptor;
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
@@ -22,5 +27,11 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
         argumentResolvers.add(userArgumentResolver);
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(taskPermissionInterceptor).addPathPatterns("/api/v1/tasks/**");
+        registry.addInterceptor(routinePermissionInterceptor).addPathPatterns("/api/v1/routines/**");
     }
 }

--- a/src/main/java/org/imgoing/api/controller/RoutineController.java
+++ b/src/main/java/org/imgoing/api/controller/RoutineController.java
@@ -5,13 +5,11 @@ import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
 import lombok.RequiredArgsConstructor;
 import org.imgoing.api.domain.entity.Routine;
-import org.imgoing.api.domain.entity.Routinetask;
 import org.imgoing.api.domain.entity.User;
 import org.imgoing.api.dto.routine.RoutineDto;
 import org.imgoing.api.dto.routine.RoutineRequest;
 import org.imgoing.api.mapper.RoutineMapper;
 import org.imgoing.api.service.RoutineService;
-import org.imgoing.api.service.RoutinetaskService;
 import org.imgoing.api.support.ImgoingResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -26,8 +24,6 @@ import java.util.stream.Collectors;
 @RequestMapping("/api/v1/routines")
 public class RoutineController {
     private final RoutineService routineService;
-    private final RoutinetaskService routinetaskService;
-
     private final RoutineMapper routineMapper;
 
     @ApiOperation(value = "루틴 생성")
@@ -69,8 +65,8 @@ public class RoutineController {
             @ApiParam(value = "루틴 id", required = true, example = "1")
             @PathVariable(value = "routineId") Long id
     ) {
-        Routine routine = routineService.getById(id);
-        String responseMessage = "루틴 " + routine.getName() + " 이(가) 삭제되었습니다.";
+        Routine routine = Routine.builder().id(id).build();
+        String responseMessage = "루틴이 삭제되었습니다.";
         routineService.delete(routine);
 
         return new ImgoingResponse<>(HttpStatus.NO_CONTENT, responseMessage);
@@ -83,12 +79,8 @@ public class RoutineController {
             @ApiParam(value = "루틴 id", required = true, example = "1")
             @PathVariable(value = "routineId") Long id,
             @RequestBody @Valid RoutineRequest routineRequest){
-        routineService.update(routineMapper.toEntity(id, user, routineRequest));
-
-        Routine routine = routineService.getById(id);
-        List<Routinetask> routinetasks = routinetaskService.update(routine, routineRequest.getTaskIdList());
-
-        RoutineDto response = routineMapper.toDto(routine, routinetasks);
+        Routine newRoutine = routineService.update(routineMapper.toEntity(id, user, routineRequest), routineRequest.getTaskIdList());
+        RoutineDto response = routineMapper.toDto(newRoutine, newRoutine.getRoutinetasks());
         return new ImgoingResponse<>(response, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/org/imgoing/api/controller/RoutineController.java
+++ b/src/main/java/org/imgoing/api/controller/RoutineController.java
@@ -86,7 +86,7 @@ public class RoutineController {
         Routine oldRoutine = (Routine)httpServletRequest.getAttribute("routine");
         Routine newRoutine = routineMapper.toEntity(id, user, routineRequest);
 
-        Routine modifiedRoutine = routineService.update(oldRoutine, newRoutine, routineRequest.getTaskIdList());
+        Routine modifiedRoutine = routineService.modify(oldRoutine, newRoutine, routineRequest.getTaskIdList());
         RoutineDto response = routineMapper.toDto(modifiedRoutine, modifiedRoutine.getRoutinetasks());
 
         return new ImgoingResponse<>(response, HttpStatus.CREATED);

--- a/src/main/java/org/imgoing/api/controller/RoutineController.java
+++ b/src/main/java/org/imgoing/api/controller/RoutineController.java
@@ -14,6 +14,7 @@ import org.imgoing.api.support.ImgoingResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -50,10 +51,11 @@ public class RoutineController {
     @GetMapping("/{routineId}")
     public ImgoingResponse<RoutineDto> get(
             User user,
+            HttpServletRequest httpServletRequest,
             @ApiParam(value = "루틴 id", required = true, example = "1")
             @PathVariable(value = "routineId") Long id
     ) {
-        Routine routine = routineService.getById(id);
+        Routine routine = (Routine)httpServletRequest.getAttribute("routine");
         RoutineDto response = routineMapper.toDto(routine, routine.getRoutinetasks());
         return new ImgoingResponse<>(response, HttpStatus.OK);
     }
@@ -62,10 +64,11 @@ public class RoutineController {
     @DeleteMapping("/{routineId}")
     public ImgoingResponse<String> delete(
             User user,
+            HttpServletRequest httpServletRequest,
             @ApiParam(value = "루틴 id", required = true, example = "1")
             @PathVariable(value = "routineId") Long id
     ) {
-        Routine routine = Routine.builder().id(id).build();
+        Routine routine = (Routine)httpServletRequest.getAttribute("routine");
         String responseMessage = "루틴이 삭제되었습니다.";
         routineService.delete(routine);
 
@@ -76,11 +79,16 @@ public class RoutineController {
     @PutMapping("/{routineId}")
     public ImgoingResponse<RoutineDto> update(
             User user,
+            HttpServletRequest httpServletRequest,
             @ApiParam(value = "루틴 id", required = true, example = "1")
             @PathVariable(value = "routineId") Long id,
             @RequestBody @Valid RoutineRequest routineRequest){
-        Routine newRoutine = routineService.update(routineMapper.toEntity(id, user, routineRequest), routineRequest.getTaskIdList());
-        RoutineDto response = routineMapper.toDto(newRoutine, newRoutine.getRoutinetasks());
+        Routine oldRoutine = (Routine)httpServletRequest.getAttribute("routine");
+        Routine newRoutine = routineMapper.toEntity(id, user, routineRequest);
+
+        Routine modifiedRoutine = routineService.update(oldRoutine, newRoutine, routineRequest.getTaskIdList());
+        RoutineDto response = routineMapper.toDto(modifiedRoutine, modifiedRoutine.getRoutinetasks());
+
         return new ImgoingResponse<>(response, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/org/imgoing/api/controller/TaskController.java
+++ b/src/main/java/org/imgoing/api/controller/TaskController.java
@@ -14,6 +14,7 @@ import org.imgoing.api.support.ImgoingResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -41,10 +42,11 @@ public class TaskController {
     @GetMapping("/{taskId}")
     public ImgoingResponse<TaskDto> get(
             User user,
+            HttpServletRequest httpServletRequest,
             @ApiParam(value = "준비항목 id", required = true, example = "1")
             @PathVariable(value = "taskId") Long id
     ) {
-        Task task = taskService.getById(id);
+        Task task = (Task)httpServletRequest.getAttribute("task");
         TaskDto response = taskMapper.toDto(task);
         return new ImgoingResponse<>(response);
     }
@@ -62,10 +64,11 @@ public class TaskController {
     @DeleteMapping("/{taskId}")
     public ImgoingResponse<String> delete(
             User user,
+            HttpServletRequest httpServletRequest,
             @ApiParam(value = "준비항목 id", required = true, example = "1")
             @PathVariable(value = "taskId") Long id
     ) {
-        Task task = Task.builder().id(id).build();
+        Task task = (Task)httpServletRequest.getAttribute("task");
         taskService.delete(task);
         return new ImgoingResponse<>(HttpStatus.NO_CONTENT, "준비항목이 삭제되었습니다.");
     }
@@ -74,12 +77,14 @@ public class TaskController {
     @PutMapping("/{taskId}")
     public ImgoingResponse<TaskDto> update (
             User user,
+            HttpServletRequest httpServletRequest,
             @ApiParam(value = "준비항목 id", required = true, example = "1")
             @PathVariable(value = "taskId") Long id,
             @RequestBody @Valid TaskRequest taskRequest
     ) {
-        Task newTask = taskService.update(taskMapper.toEntity(id, user, taskRequest));
-        TaskDto response = taskMapper.toDto(newTask);
+        Task oldTask = (Task)httpServletRequest.getAttribute("task");
+        Task newTask = taskMapper.toEntity(id, user, taskRequest);
+        TaskDto response = taskMapper.toDto(taskService.update(oldTask, newTask));
         return new ImgoingResponse<>(response, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/org/imgoing/api/controller/TaskController.java
+++ b/src/main/java/org/imgoing/api/controller/TaskController.java
@@ -32,7 +32,7 @@ public class TaskController {
             User user,
             @RequestBody @Valid TaskRequest taskRequest
     ) {
-        Task newTask = taskService.create(taskMapper.requestToEntity(user, taskRequest));
+        Task newTask = taskService.create(taskMapper.toEntity(user, taskRequest));
         TaskDto response = taskMapper.toDto(newTask);
         return new ImgoingResponse<>(response, HttpStatus.CREATED);
     }
@@ -65,11 +65,9 @@ public class TaskController {
             @ApiParam(value = "준비항목 id", required = true, example = "1")
             @PathVariable(value = "taskId") Long id
     ) {
-        Task task = taskService.getById(id);
-        String name = task.getName();
+        Task task = Task.builder().id(id).build();
         taskService.delete(task);
-        String responseMessage = name + " 이(가) 삭제되었습니다.";
-        return new ImgoingResponse<>(HttpStatus.NO_CONTENT, responseMessage);
+        return new ImgoingResponse<>(HttpStatus.NO_CONTENT, "준비항목이 삭제되었습니다.");
     }
 
     @ApiOperation(value = "준비항목 수정")
@@ -80,8 +78,8 @@ public class TaskController {
             @PathVariable(value = "taskId") Long id,
             @RequestBody @Valid TaskRequest taskRequest
     ) {
-        Task updateTask = taskMapper.requestToEntity(id, user, taskRequest);
-        TaskDto response = taskMapper.toDto(taskService.update(updateTask));
+        Task newTask = taskService.update(taskMapper.toEntity(id, user, taskRequest));
+        TaskDto response = taskMapper.toDto(newTask);
         return new ImgoingResponse<>(response, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/org/imgoing/api/controller/TaskController.java
+++ b/src/main/java/org/imgoing/api/controller/TaskController.java
@@ -75,7 +75,7 @@ public class TaskController {
 
     @ApiOperation(value = "준비항목 수정")
     @PutMapping("/{taskId}")
-    public ImgoingResponse<TaskDto> update (
+    public ImgoingResponse<TaskDto> modify(
             User user,
             HttpServletRequest httpServletRequest,
             @ApiParam(value = "준비항목 id", required = true, example = "1")
@@ -84,7 +84,7 @@ public class TaskController {
     ) {
         Task oldTask = (Task)httpServletRequest.getAttribute("task");
         Task newTask = taskMapper.toEntity(id, user, taskRequest);
-        TaskDto response = taskMapper.toDto(taskService.update(oldTask, newTask));
+        TaskDto response = taskMapper.toDto(taskService.modify(oldTask, newTask));
         return new ImgoingResponse<>(response, HttpStatus.CREATED);
     }
 }

--- a/src/main/java/org/imgoing/api/domain/entity/Routine.java
+++ b/src/main/java/org/imgoing/api/domain/entity/Routine.java
@@ -7,7 +7,7 @@ import org.imgoing.api.config.BaseTime;
 
 import javax.persistence.*;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 @Getter
@@ -38,7 +38,7 @@ public class Routine extends BaseTime {
     }
 
     public List<Routinetask> getRoutinetasks() {
-        if(routinetasks != null) Collections.sort(routinetasks);
+        if(routinetasks != null) routinetasks.sort(Comparator.comparing(Routinetask::getPriority));
         return routinetasks;
     }
 

--- a/src/main/java/org/imgoing/api/domain/entity/Routine.java
+++ b/src/main/java/org/imgoing/api/domain/entity/Routine.java
@@ -38,7 +38,7 @@ public class Routine extends BaseTime {
     }
 
     public List<Routinetask> getRoutinetasks() {
-        if(routinetasks != null) routinetasks.sort(Comparator.comparing(Routinetask::getPriority));
+        if(!routinetasks.isEmpty()) routinetasks.sort(Comparator.comparing(Routinetask::getPriority));
         return routinetasks;
     }
 

--- a/src/main/java/org/imgoing/api/domain/entity/Routinetask.java
+++ b/src/main/java/org/imgoing/api/domain/entity/Routinetask.java
@@ -13,7 +13,7 @@ import javax.persistence.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Routinetask extends BaseTime implements Comparable {
+public class Routinetask extends BaseTime {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "id", nullable = false)
@@ -31,12 +31,6 @@ public class Routinetask extends BaseTime implements Comparable {
 
     @Column(nullable = false)
     private Integer priority;
-
-    @Override
-    public int compareTo(Object o) {
-        Routinetask routinetask = (Routinetask)o;
-        return this.priority - routinetask.priority;
-    }
 
     public void addPriority(Integer priority) {
         this.priority = priority;

--- a/src/main/java/org/imgoing/api/mapper/TaskMapper.java
+++ b/src/main/java/org/imgoing/api/mapper/TaskMapper.java
@@ -14,15 +14,16 @@ public interface TaskMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "user", source = "user")
     @Mapping(target = "routinetasks", ignore = true)
-    Task requestToEntity(User user, TaskRequest taskRequest);
+    Task toEntity(User user, TaskRequest taskRequest);
 
     @Mapping(target = "id", source = "id")
     @Mapping(target = "user", source = "user")
     @Mapping(target = "routinetasks", ignore = true)
-    Task requestToEntity(Long id, User user, TaskRequest taskRequest);
+    Task toEntity(Long id, User user, TaskRequest taskRequest);
 
+    @Mapping(target = "user", ignore = true)
     @Mapping(target = "routinetasks", ignore = true)
-    Task responseToEntity(TaskDto taskDto);
+    Task toEntity(TaskDto taskDto);
 
     TaskDto toDto(Task task);
 }

--- a/src/main/java/org/imgoing/api/service/PlanService.java
+++ b/src/main/java/org/imgoing/api/service/PlanService.java
@@ -148,7 +148,7 @@ public class PlanService {
     public List<Task> findNotBookmarkedTask (List<TaskDto> taskDtos) {
         return taskDtos.stream()
                 .filter(taskDto -> !taskDto.getIsBookmarked())
-                .map(taskMapper::responseToEntity)
+                .map(taskMapper::toEntity)
                 .collect(Collectors.toList());
     }
 
@@ -156,7 +156,7 @@ public class PlanService {
     public List<Task> findBookmarkedTask (List<TaskDto> taskDtos) {
         return taskDtos.stream()
                 .filter(taskDto -> taskDto.getIsBookmarked())
-                .map(taskMapper::responseToEntity)
+                .map(taskMapper::toEntity)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/org/imgoing/api/service/RoutineService.java
+++ b/src/main/java/org/imgoing/api/service/RoutineService.java
@@ -20,15 +20,10 @@ public class RoutineService {
 
     @Transactional
     public Routine create(Routine newRoutine, List<Long> taskIdList){
+        if(taskIdList.isEmpty()) throw new ImgoingException(ImgoingError.BAD_REQUEST, "루틴에는 최소 하나 이상의 준비항목이 포함되어야 합니다.");
         newRoutine.registerRoutinetasks(taskService.getListById(taskIdList));
         routinetaskService.createAll(newRoutine.getRoutinetasks());
         return routineRepository.save(newRoutine);
-    }
-
-    @Transactional(readOnly = true)
-    public Routine getById(Long id){
-        return routineRepository.findById(id)
-                .orElseThrow(() -> new ImgoingException(ImgoingError.BAD_REQUEST, "존재하지 않는 루틴입니다."));
     }
 
     @Transactional(readOnly = true)
@@ -42,10 +37,9 @@ public class RoutineService {
     }
 
     @Transactional
-    public Routine update(Routine updateRoutine, List<Long> updateTaskIdList){ // mapper에 의해 새로 생성된 Routine
-        Routine oldRoutine = getById(updateRoutine.getId());
-        oldRoutine.modifyRoutine(updateRoutine);
-        Routine newRoutine = routineRepository.save(oldRoutine);
+    public Routine update(Routine oldRoutine, Routine newRoutine, List<Long> updateTaskIdList){ // mapper에 의해 새로 생성된 Routine
+        oldRoutine.modifyRoutine(newRoutine);
+        routineRepository.save(oldRoutine);
 
         List<Routinetask> routinetasks = routinetaskService.update(newRoutine, updateTaskIdList);
 

--- a/src/main/java/org/imgoing/api/service/RoutineService.java
+++ b/src/main/java/org/imgoing/api/service/RoutineService.java
@@ -2,6 +2,7 @@ package org.imgoing.api.service;
 
 import lombok.RequiredArgsConstructor;
 import org.imgoing.api.domain.entity.Routine;
+import org.imgoing.api.domain.entity.Routinetask;
 import org.imgoing.api.repository.RoutineRepository;
 import org.imgoing.api.support.ImgoingError;
 import org.imgoing.api.support.ImgoingException;
@@ -41,11 +42,18 @@ public class RoutineService {
     }
 
     @Transactional
-    public Routine update(Routine newRoutine){
-        Long id = newRoutine.getId();
-        Routine oldRoutine = getById(id);
+    public Routine update(Routine updateRoutine, List<Long> updateTaskIdList){ // mapper에 의해 새로 생성된 Routine
+        Routine oldRoutine = getById(updateRoutine.getId());
+        oldRoutine.modifyRoutine(updateRoutine);
+        Routine newRoutine = routineRepository.save(oldRoutine);
 
-        oldRoutine.modifyRoutine(newRoutine);
-        return routineRepository.save(oldRoutine);
+        List<Routinetask> routinetasks = routinetaskService.update(newRoutine, updateTaskIdList);
+
+        return Routine.builder()
+                .id(newRoutine.getId())
+                .name(newRoutine.getName())
+                .user(newRoutine.getUser())
+                .routinetasks(routinetasks)
+                .build();
     }
 }

--- a/src/main/java/org/imgoing/api/service/RoutineService.java
+++ b/src/main/java/org/imgoing/api/service/RoutineService.java
@@ -37,7 +37,7 @@ public class RoutineService {
     }
 
     @Transactional
-    public Routine update(Routine oldRoutine, Routine newRoutine, List<Long> updateTaskIdList){ // mapper에 의해 새로 생성된 Routine
+    public Routine modify(Routine oldRoutine, Routine newRoutine, List<Long> updateTaskIdList){ // mapper에 의해 새로 생성된 Routine
         oldRoutine.modifyRoutine(newRoutine);
         routineRepository.save(oldRoutine);
 

--- a/src/main/java/org/imgoing/api/service/TaskService.java
+++ b/src/main/java/org/imgoing/api/service/TaskService.java
@@ -50,7 +50,7 @@ public class TaskService {
     }
 
     @Transactional
-    public Task update(Task oldTask, Task newTask){
+    public Task modify(Task oldTask, Task newTask){
         oldTask.modifyTask(newTask);
         return taskRepository.save(oldTask);
     }

--- a/src/main/java/org/imgoing/api/service/TaskService.java
+++ b/src/main/java/org/imgoing/api/service/TaskService.java
@@ -67,5 +67,4 @@ public class TaskService {
     public void deleteAll(List<Task> tasks) {
         taskRepository.deleteAll(tasks);
     }
-
 }

--- a/src/main/java/org/imgoing/api/service/TaskService.java
+++ b/src/main/java/org/imgoing/api/service/TaskService.java
@@ -50,10 +50,7 @@ public class TaskService {
     }
 
     @Transactional
-    public Task update(Task newTask){
-        Long id = newTask.getId();
-        Task oldTask = getById(id);
-
+    public Task update(Task oldTask, Task newTask){
         oldTask.modifyTask(newTask);
         return taskRepository.save(oldTask);
     }


### PR DESCRIPTION
## Routine, Task 접근 시 권한을 체크하는 Interceptor 등록

HttpMethod가
- `GET`이고 `pathVariables`이 비어있을때 == id로 단일 조회할때
- `PUT`일때, `DELETE`일때

UserId 비교해서 같으면 pass, 틀리면 Exception 던집니다.

제네릭이랑 인터페이스 잘쓰면 클래스 하나로 관리할 수도 있을 것 같았는데 

```Parameter 0 of constructor in org.imgoing.api.application.interceptor.PermissionInterceptor required a single bean, but 2 were found:```

에러가 뜨면서 DI에 필요한 Bean을 찾지 못하는 이슈가 있었음.
같은 타입의 Bean이 컨테이너에 여러개 있어서 저런 에러가 뜨는 것으로 사료됨.
@Primary나 @Qualifier를 써보라는 답변이 많은데 전자는 하나밖에 지정을 못하고 후자는 따로 나눠놓는 거랑 다를게 없으니, 그냥 분리시켜놨음.

리팩토링 가능하다면 부탁드립니다!


## 인터셉터를 등록하면 추가적으로 한번씩 더 조회하게 되는데, 성능 문제는 없을까?

- 딱히 쿼리를 안날려도 되는 삭제 API에는 Builder로 인스턴스를 생성해서 삭제하는 방식으로 변경 (이미 인터셉터에서 해당 데이터가 존재하는 것과 소유자라는 것이 증명되었으니)

### 그럼 나머지의 경우는?
- 수정시 삭제와 비슷하게 처리하면 Auditing이 null이 되버리는 이슈 존재
- Routine과 Task(정확히는 Routinetask)는 언제나 같이 다니는 사이라 즉시로딩으로 설정하고 참조하는 일이 잦음 -> Service에서 조회해오지 않으면 불편 & 비효율적
-  개발 편의성과 성능의 Tradeoff로 남는가, 개선 방법이 없을까?

## etc.

- Mapper 인터페이스 명 변경