### PR TITLE
Fix/plan create 일정 생성 관련 수정

### DIFF
--- a/src/main/java/org/imgoing/api/controller/PlanController.java
+++ b/src/main/java/org/imgoing/api/controller/PlanController.java
@@ -4,9 +4,9 @@ import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
 import org.imgoing.api.domain.entity.User;
 import org.imgoing.api.domain.vo.RemainingTimeInfoVo;
+import org.imgoing.api.dto.plan.PlanDto;
 import org.imgoing.api.dto.plan.PlanRequest;
 import org.imgoing.api.domain.entity.Plan;
-import org.imgoing.api.dto.plan.PlanResponse;
 import org.imgoing.api.dto.route.RemainingTimeResponse;
 import org.imgoing.api.mapper.PlanMapper;
 import org.imgoing.api.service.PlanService;
@@ -32,17 +32,17 @@ public class PlanController {
             @ApiResponse(code = 201, message = "일정 생성 성공", response = PlanRequest.class),
             @ApiResponse(code = 400, message = "일정 생성 실패")
     })
-    public ImgoingResponse<PlanResponse> create(User user, @RequestBody @Valid PlanRequest.Create planSaveRequest) {
+    public ImgoingResponse<PlanDto> create(User user, @RequestBody @Valid PlanRequest.Create planSaveRequest) {
         Plan plan = planService.createPlan(user, planSaveRequest);
-        return new ImgoingResponse<>(planMapper.toResponse(plan, plan.getTaskList()), HttpStatus.CREATED);
+        return new ImgoingResponse<>(planMapper.toDto(plan, plan.getTaskList()), HttpStatus.CREATED);
     }
 
     @ApiOperation(value = "일정 전체 조회", notes = "사용자의 전체 일정 조회")
     @GetMapping
     @ApiResponse(code = 200, message = "일정 전체 조회 성공", response = List.class)
-    public ImgoingResponse<List<PlanResponse>> getAllPlans(User user) {
-        List<PlanResponse> planResponses = planService.getPlansByUser(user).stream()
-                .map(plan -> planMapper.toResponse(plan, plan.getTaskList()))
+    public ImgoingResponse<List<PlanDto>> getAllPlans(User user) {
+        List<PlanDto> planResponses = planService.getPlansByUser(user).stream()
+                .map(plan -> planMapper.toDto(plan, plan.getTaskList()))
                 .collect(Collectors.toList());
 
         return new ImgoingResponse<>(planResponses, HttpStatus.OK);
@@ -51,13 +51,13 @@ public class PlanController {
     @ApiOperation(value = "일정 조회", notes = "사용자의 특정 일정 조회")
     @GetMapping("/{planId}")
     @ApiResponse(code = 200, message = "일정 조회 성공", response = PlanRequest.class)
-    public ImgoingResponse<PlanResponse> getPlan(
+    public ImgoingResponse<PlanDto> getPlan(
             User user,
             @ApiParam(value = "일정 id", required = true, example = "1")
             @PathVariable(value = "planId") Long planId
     ) {
         Plan plan = planService.getPlan(user.getId(), planId);
-        return new ImgoingResponse<>(planMapper.toResponse(plan, plan.getTaskList()));
+        return new ImgoingResponse<>(planMapper.toDto(plan, plan.getTaskList()));
     }
 
     @ApiOperation(value = "일정 수정")
@@ -66,9 +66,9 @@ public class PlanController {
             @ApiResponse(code = 200, message = "일정 수정 성공", response = PlanRequest.class),
             @ApiResponse(code = 400, message = "일정 수정 실패")
     })
-    public ImgoingResponse<PlanResponse> update (User user, @RequestBody @Valid PlanRequest planRequest) {
+    public ImgoingResponse<PlanDto> update (User user, @RequestBody @Valid PlanRequest planRequest) {
         Plan plan = planService.updatePlan(user.getId(), planRequest);
-        return new ImgoingResponse<>(planMapper.toResponse(plan, plan.getTaskList()));
+        return new ImgoingResponse<>(planMapper.toDto(plan, plan.getTaskList()));
     }
 
     @ApiOperation(value = "일정 삭제")

--- a/src/main/java/org/imgoing/api/controller/PlanController.java
+++ b/src/main/java/org/imgoing/api/controller/PlanController.java
@@ -4,8 +4,9 @@ import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
 import org.imgoing.api.domain.entity.User;
 import org.imgoing.api.domain.vo.RemainingTimeInfoVo;
-import org.imgoing.api.dto.PlanDto;
+import org.imgoing.api.dto.plan.PlanRequest;
 import org.imgoing.api.domain.entity.Plan;
+import org.imgoing.api.dto.plan.PlanResponse;
 import org.imgoing.api.dto.route.RemainingTimeResponse;
 import org.imgoing.api.mapper.PlanMapper;
 import org.imgoing.api.service.PlanService;
@@ -14,7 +15,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,46 +29,46 @@ public class PlanController {
     @ApiOperation(value = "일정 생성")
     @PostMapping
     @ApiResponses({
-            @ApiResponse(code = 201, message = "일정 생성 성공", response = PlanDto.class),
+            @ApiResponse(code = 201, message = "일정 생성 성공", response = PlanRequest.class),
             @ApiResponse(code = 400, message = "일정 생성 실패")
     })
-    public ImgoingResponse<PlanDto> create(User user, @RequestBody @Valid PlanDto.Create planSaveRequest) {
+    public ImgoingResponse<PlanResponse> create(User user, @RequestBody @Valid PlanRequest.Create planSaveRequest) {
         Plan plan = planService.createPlan(user, planSaveRequest);
-        return new ImgoingResponse<>(planMapper.toDto(plan, plan.getTaskList()), HttpStatus.CREATED);
+        return new ImgoingResponse<>(planMapper.toResponse(plan, plan.getTaskList()), HttpStatus.CREATED);
     }
 
     @ApiOperation(value = "일정 전체 조회", notes = "사용자의 전체 일정 조회")
     @GetMapping
     @ApiResponse(code = 200, message = "일정 전체 조회 성공", response = List.class)
-    public ImgoingResponse<List<PlanDto>> getAllPlans(User user) {
-        List<PlanDto> planDtos = planService.getPlansByUser(user).stream()
-                .map(plan -> planMapper.toDto(plan, plan.getTaskList()))
+    public ImgoingResponse<List<PlanResponse>> getAllPlans(User user) {
+        List<PlanResponse> planResponses = planService.getPlansByUser(user).stream()
+                .map(plan -> planMapper.toResponse(plan, plan.getTaskList()))
                 .collect(Collectors.toList());
 
-        return new ImgoingResponse<>(planDtos, HttpStatus.OK);
+        return new ImgoingResponse<>(planResponses, HttpStatus.OK);
     }
 
     @ApiOperation(value = "일정 조회", notes = "사용자의 특정 일정 조회")
     @GetMapping("/{planId}")
-    @ApiResponse(code = 200, message = "일정 조회 성공", response = PlanDto.class)
-    public ImgoingResponse<PlanDto> getPlan(
+    @ApiResponse(code = 200, message = "일정 조회 성공", response = PlanRequest.class)
+    public ImgoingResponse<PlanResponse> getPlan(
             User user,
             @ApiParam(value = "일정 id", required = true, example = "1")
             @PathVariable(value = "planId") Long planId
     ) {
         Plan plan = planService.getPlan(user.getId(), planId);
-        return new ImgoingResponse<>(planMapper.toDto(plan, plan.getTaskList()));
+        return new ImgoingResponse<>(planMapper.toResponse(plan, plan.getTaskList()));
     }
 
     @ApiOperation(value = "일정 수정")
     @PutMapping
     @ApiResponses({
-            @ApiResponse(code = 200, message = "일정 수정 성공", response = PlanDto.class),
+            @ApiResponse(code = 200, message = "일정 수정 성공", response = PlanRequest.class),
             @ApiResponse(code = 400, message = "일정 수정 실패")
     })
-    public ImgoingResponse<PlanDto> update (User user, @RequestBody @Valid PlanDto planDto) {
-        Plan plan = planService.updatePlan(user.getId(), planDto);
-        return new ImgoingResponse<>(planMapper.toDto(plan, plan.getTaskList()));
+    public ImgoingResponse<PlanResponse> update (User user, @RequestBody @Valid PlanRequest planRequest) {
+        Plan plan = planService.updatePlan(user.getId(), planRequest);
+        return new ImgoingResponse<>(planMapper.toResponse(plan, plan.getTaskList()));
     }
 
     @ApiOperation(value = "일정 삭제")

--- a/src/main/java/org/imgoing/api/domain/entity/Plan.java
+++ b/src/main/java/org/imgoing/api/domain/entity/Plan.java
@@ -59,10 +59,6 @@ public class Plan extends BaseTime {
     @OneToMany(mappedBy = "plan", orphanRemoval = true, fetch = FetchType.EAGER)
     private List<Plantask> plantasks = new ArrayList<>();
 
-    public void addUser(User user) {
-        this.user = user;
-    }
-
     public void registerPlantask(List<Task> tasks) {
         this.plantasks.clear();
         List<Plantask> plantasks = tasks.stream()
@@ -74,9 +70,9 @@ public class Plan extends BaseTime {
         this.plantasks.addAll(plantasks);
     }
 
+    // plantask 새로 추가
     public void registerPlantasks(List<Plantask> plantasks) {
-        this.plantasks.clear();
-        this.plantasks.addAll(plantasks);
+        this.plantasks = plantasks;
     }
 
     public List<Task> getTaskList() {

--- a/src/main/java/org/imgoing/api/dto/plan/PlanDto.java
+++ b/src/main/java/org/imgoing/api/dto/plan/PlanDto.java
@@ -15,20 +15,29 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
-public class PlanResponse {
+public class PlanDto {
     private Long id;
+
     private String name;
+
     private String departureName;
+
     private Double departureLat;
+
     private Double departureLng;
+
     private String arrivalName;
 
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime arrivalAt;
 
     private Double arrivalLat;
+
     private Double arrivalLng;
+
     private String memo;
+
     private String belongings;
+
     private List<TaskDto> task;
 }

--- a/src/main/java/org/imgoing/api/dto/plan/PlanRequest.java
+++ b/src/main/java/org/imgoing/api/dto/plan/PlanRequest.java
@@ -1,5 +1,6 @@
-package org.imgoing.api.dto;
+package org.imgoing.api.dto.plan;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
@@ -17,10 +18,9 @@ import java.util.List;
 
 @SuperBuilder
 @Getter
-@Setter
 @NoArgsConstructor
 @ApiModel(value = "악속 정보", description = "약속 모델")
-public class PlanDto {
+public class PlanRequest {
     @ApiModelProperty(value = "일정 id")
     private Long id;
 
@@ -53,7 +53,8 @@ public class PlanDto {
     private Double arrivalLng;
 
     @NotNull(message = "도착 시간은 필수값 입니다.")
-    @ApiModelProperty(required = true, value = "도착 시간", example = "2021-10-15T15:46:54.191Z")
+    @ApiModelProperty(required = true, value = "도착 시간", example = "2021-12-15 15:46:54")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime arrivalAt;
 
     @Length(max = 100, message = "메모는 최대 100자 까지 입니다.")
@@ -72,7 +73,7 @@ public class PlanDto {
     @NoArgsConstructor
     @AllArgsConstructor
     @ApiModel(value = "플랜 생성 모델")
-    public static class Create extends PlanDto {
+    public static class Create extends PlanRequest {
         @ApiModelProperty(value = "북마크 리스트")
         private List<Long> bookmarkedTaskIds;
     }

--- a/src/main/java/org/imgoing/api/dto/plan/PlanResponse.java
+++ b/src/main/java/org/imgoing/api/dto/plan/PlanResponse.java
@@ -1,0 +1,34 @@
+package org.imgoing.api.dto.plan;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+import org.imgoing.api.dto.task.TaskDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@SuperBuilder
+@Getter
+@Setter
+@NoArgsConstructor
+public class PlanResponse {
+    private Long id;
+    private String name;
+    private String departureName;
+    private Double departureLat;
+    private Double departureLng;
+    private String arrivalName;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime arrivalAt;
+
+    private Double arrivalLat;
+    private Double arrivalLng;
+    private String memo;
+    private String belongings;
+    private List<TaskDto> task;
+}

--- a/src/main/java/org/imgoing/api/mapper/PlanMapper.java
+++ b/src/main/java/org/imgoing/api/mapper/PlanMapper.java
@@ -2,9 +2,9 @@ package org.imgoing.api.mapper;
 
 import org.imgoing.api.domain.entity.Task;
 import org.imgoing.api.domain.entity.User;
+import org.imgoing.api.dto.plan.PlanDto;
 import org.imgoing.api.dto.plan.PlanRequest;
 import org.imgoing.api.domain.entity.Plan;
-import org.imgoing.api.dto.plan.PlanResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -15,7 +15,7 @@ import java.util.List;
         unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface PlanMapper {
     @Mapping(source = "tasks", target = "task")
-    PlanResponse toResponse(Plan plan, List<Task> tasks);
+    PlanDto toDto(Plan plan, List<Task> tasks);
 
     Plan toEntity(PlanRequest planRequest);
 

--- a/src/main/java/org/imgoing/api/mapper/PlanMapper.java
+++ b/src/main/java/org/imgoing/api/mapper/PlanMapper.java
@@ -2,8 +2,9 @@ package org.imgoing.api.mapper;
 
 import org.imgoing.api.domain.entity.Task;
 import org.imgoing.api.domain.entity.User;
-import org.imgoing.api.dto.PlanDto;
+import org.imgoing.api.dto.plan.PlanRequest;
 import org.imgoing.api.domain.entity.Plan;
+import org.imgoing.api.dto.plan.PlanResponse;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -14,11 +15,11 @@ import java.util.List;
         unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface PlanMapper {
     @Mapping(source = "tasks", target = "task")
-    PlanDto toDto(Plan plan, List<Task> tasks);
+    PlanResponse toResponse(Plan plan, List<Task> tasks);
 
-    Plan toEntity(PlanDto planDto);
+    Plan toEntity(PlanRequest planRequest);
 
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "user", source = "user")
-    Plan toEntityForSave(User user, PlanDto.Create dto);
+    Plan toEntityForSave(User user, PlanRequest.Create dto);
 }

--- a/src/main/java/org/imgoing/api/repository/PlanRepository.java
+++ b/src/main/java/org/imgoing/api/repository/PlanRepository.java
@@ -16,5 +16,7 @@ public interface PlanRepository extends JpaRepository<Plan, Long> {
     @Query(value = "SELECT * FROM plan_tb WHERE plan_tb.user_id = :userId", nativeQuery = true)
     List<Plan> findAllByUserId(Long userId);
 
+    List<Plan> findByUserIdAndArrivalAtGreaterThanEqualOrderByArrivalAtAsc(Long userId, LocalDateTime now);
+
     Optional<Plan> findTopByUserAndArrivalAtGreaterThanOrderByArrivalAtAsc (User user, LocalDateTime now);
 }


### PR DESCRIPTION
[일정 생성/응답 시 id]
- 일정 생성 시 id 받지 않아도 되도록 수정
- 일정 생성 후 response에 id 들어가도록 수정

[일정 조회]
- 전체 일정 조회 시 도착시간이 현재 시간보다 빠른 것만 조회되도록 함
- 전체 일정 조회 시 도착시간 순으로 오름차순 하여 전송함

[도착시간 format]
- 일정 생성 시 도착시간 format yyyy-mm-dd hh:mm:ss 로 받음
- 일정 생성 후 response, 조회 response의 도착시간 format yyyy-mm-dd hh:mm:ss 로 수정

[체크해주세요]
- 일정 생성 시 도착시간이 DB 에 yyyy-mm-ddThh:mm:ss 로 저장되는데, '가장 최근 약속까지 남은 시간' 조회하려니까 에러가 떠. 혹시 내가 수정한거 때문에 그런건지 한번 확인해줘!
- planDto -> planRequest / planResponse 로 나눴어. 나눈 이유는 plan받을 땐 yyyy-mm-dd hh:mm:ss 를 LocalDateTime으로, 응답할땐 그 반대로 변환 해야해서 @JsonFormat을 각각 다르게 달아놨어. 혹시 다른 좋은 방법 있으면 알려줘!